### PR TITLE
Remove indent from formatted examples.

### DIFF
--- a/example.go
+++ b/example.go
@@ -86,7 +86,6 @@ func (p *myPres) exampleMDFunc(info *godoc.PageInfo, funcName, indent string) st
 			code = strings.Replace(code, "\n    ", "\n", -1)
 		}
 		code = strings.Trim(code, "\n")
-		code = strings.Replace(code, "\n", "\n\t", -1)
 
 		buf.WriteString(indent)
 		buf.WriteString("Example:\n\n")


### PR DESCRIPTION
The implementation doesn't correctly indent the first line. Since Godoc doesn't indent examples, and the examples are inside a code-block already, the easiest fix seems to be to remove the indent.